### PR TITLE
Support HTTPS

### DIFF
--- a/L.Control.Geonames.js
+++ b/L.Control.Geonames.js
@@ -12,7 +12,7 @@ L.Control.Geonames = L.Control.extend({
     _hasResults: false,
     options: {
         //position: 'topcenter',  // in addition to standard 4 corner Leaflet control layout, this will position and size from top center
-        geonamesURL: '//api.geonames.org/searchJSON',  // override this if using a proxy to get connection to geonames
+        geonamesURL: 'https://secure.geonames.org/searchJSON',  // override this if using a proxy to get connection to geonames
         username: '', //Geonames account username.  Must be provided
         maxresults: 5, //Maximum number of results to display per search
         zoomLevel: null, //Max zoom level to zoom to for location.  If null, will use the map's max zoom level.


### PR DESCRIPTION
The `api.geonames.org` endpoint doesn't support HTTPS, resulting in a broken control on any HTTPS pages that use it.

This PR instead uses the `secure.geonames.org` endpoint, which _does_ support HTTPS, and will still work on HTTP pages.